### PR TITLE
Join parfile

### DIFF
--- a/src/join.c
+++ b/src/join.c
@@ -1,30 +1,41 @@
-/* Copyright 2013. The Regents of the University of California.
+/* Copyright 2013-2015. The Regents of the University of California.
  * All rights reserved. Use of this source code is governed by 
  * a BSD-style license which can be found in the LICENSE file.
  *
  * Authors: 
  * 2013 Martin Uecker <uecker@eecs.berkeley.edu>
+ * 2015 Jonathan Tamir <jtamir@eecs.berkeley.edu>
  */
 
 
 #include <stdlib.h>
+#include <stdbool.h>
 #include <assert.h>
 #include <stdio.h>
 #include <complex.h>
+#include <string.h>
 #include <getopt.h>
 
 #include "num/multind.h"
 
 #include "misc/mmio.h"
+#include "misc/debug.h"
 
 
 #ifndef DIMS
 #define DIMS 16
 #endif
 
+#ifndef CFL_SIZE
+#define CFL_SIZE sizeof(complex float)
+#endif
+
 static void usage(const char* name, FILE* fp)
 {
-	fprintf(fp, "Usage: %s dimension <input1> ... <inputn> <output>\n", name);
+	fprintf(fp, "Usage 1: %s dimension <input1> ... <inputn> <output>\n", name);
+	fprintf(fp, "\t Example: %s 0 slice_001 slice_002 slice_003 full_data\n\n", name);
+	fprintf(fp, "Usage 2: %s -p dimension <n> <input_format> <output>\n", name);
+	fprintf(fp, "\t Example: %s -p 0 256 slice_%%03d full_data\n", name);
 }
 
 static void help(void)
@@ -36,7 +47,9 @@ static void help(void)
 int main_join(int argc, char* argv[])
 {
 	int c;
-	while (-1 != (c = getopt(argc, argv, "h"))) {
+	bool parfile = false;
+
+	while (-1 != (c = getopt(argc, argv, "hp"))) {
 
 		switch (c) {
 
@@ -45,31 +58,48 @@ int main_join(int argc, char* argv[])
 			help();
 			exit(0);
 
+		case 'p':
+			parfile = true;
+			break;
+
 		default:
 			usage(argv[0], stderr);
 			exit(1);
 		}
 	}
 
-	if (argc - optind < 3) {
-
+	if ((parfile && argc - optind != 4) || (!parfile && argc - optind < 3)) {
 		usage(argv[0], stderr);
 		exit(1);
 	}
 
 	int N = DIMS;
-	int count = argc - optind - 2;
 
-	int dim = atoi(argv[optind]);
+	int dim = atoi(argv[optind + 0]);
 	assert(dim < N);
 
-        long in_dims[count][N];
+	int count = parfile ? atoi(argv[optind + 1]) : argc - optind - 2;
+
+	long in_dims[count][N];
+	long offsets[count];
 	complex float* idata[count];
 	long sum = 0;
 
+	// figure out size of output
+	// FIXME: this approach requires loading all the data at once, effectively requiring 2X the output memory
 	for (int i = 0; i < count; i++) {
 
-		idata[i] = load_cfl(argv[optind + 1 + i], N, in_dims[i]);
+		char fname[256];
+
+		if (parfile)
+			sprintf(fname, argv[optind + 2], i);
+		else
+			strcpy(fname, argv[optind + 1 + i]);
+
+		debug_printf(DP_DEBUG1, "loading %s\n", fname);
+		idata[i] = load_cfl(fname, N, in_dims[i]);
+		offsets[i] = sum;
+
 		sum += in_dims[i][dim];
 
 		for (int j = 0; j < N; j++)
@@ -83,21 +113,26 @@ int main_join(int argc, char* argv[])
 
 	out_dims[dim] = sum;
 
-        complex float* out_data = create_cfl(argv[argc - 1], N, out_dims);
+	complex float* out_data = create_cfl(argv[argc - 1], N, out_dims);
 
 	long ostr[N];
-	md_calc_strides(N, ostr, out_dims, sizeof(complex float));
-	long opos = 0;
+	md_calc_strides(N, ostr, out_dims, CFL_SIZE);
 
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
 	for (int i = 0; i < count; i++) {
 
+		long pos[N];
+		md_singleton_strides(N, pos);
+		pos[dim] = offsets[i];
+
 		long istr[N];
-		md_calc_strides(N, istr, in_dims[i], sizeof(complex float));
+		md_calc_strides(N, istr, in_dims[i], CFL_SIZE);
 
-		md_copy2(N, in_dims[i], ostr, (char*)out_data + opos * ostr[dim], istr, idata[i], sizeof(complex float));
+		md_copy_block(N, pos, out_dims, out_data, in_dims[i], idata[i], CFL_SIZE);
 		unmap_cfl(N, in_dims[i], idata[i]);
-
-		opos += in_dims[i][dim];
+		debug_printf(DP_DEBUG1, "done copying file %d\n", i);
 	}
 
 	unmap_cfl(N, out_dims, out_data);

--- a/src/pics.c
+++ b/src/pics.c
@@ -159,12 +159,16 @@ int main_pics(int argc, char* argv[])
 	float restrict_fov = -1.;
 	const char* pat_file = NULL;
 	const char* traj_file = NULL;
-	const char* image_truth_file = NULL;
-	bool im_truth = false;
 	bool scale_im = false;
 	bool eigen = false;
 	float scaling = 0.;
 
+
+	const char* image_truth_file = NULL;
+	bool im_truth = false;
+
+	const char* image_start_file = NULL;
+	bool warm_start = false;
 
 	bool hogwild = false;
 	bool fast = false;
@@ -178,7 +182,7 @@ int main_pics(int argc, char* argv[])
 		debug_printf(DP_WARN, "The \'sense\' command is deprecated. Use \'pics\' instead.\n");
 
 	int c;
-	while (-1 != (c = getopt(argc, argv, "Fq:l:r:s:i:u:o:O:f:t:cT:Imngehp:w:Sd:R:HC:"))) {
+	while (-1 != (c = getopt(argc, argv, "W:Fq:l:r:s:i:u:o:O:f:t:cT:Imngehp:w:Sd:R:HC:"))) {
 
 		char rt[5];
 
@@ -259,6 +263,12 @@ int main_pics(int argc, char* argv[])
 			im_truth = true;
 			image_truth_file = strdup(optarg);
 			assert(NULL != image_truth_file);
+			break;
+
+		case 'W':
+			warm_start = true;
+			image_start_file = strdup(optarg);
+			assert(NULL != image_start_file);
 			break;
 
 		case 'd':
@@ -652,6 +662,24 @@ int main_pics(int argc, char* argv[])
 
 		image_truth = load_cfl(image_truth_file, DIMS, img_truth_dims);
 		//md_zsmul(DIMS, img_dims, image_truth, image_truth, 1. / scaling);
+	}
+
+	long img_start_dims[DIMS];
+	complex float* image_start = NULL;
+
+	if (warm_start) { 
+
+		debug_printf(DP_DEBUG1, "Warm start: %s\n", image_start_file);
+		image_start = load_cfl(image_start_file, DIMS, img_start_dims);
+		assert(md_check_compat(DIMS, 0u, img_start_dims, img_dims));
+		md_copy(DIMS, img_dims, image, image_start, CFL_SIZE);
+
+		free((void*)image_start_file);
+		unmap_cfl(DIMS, img_dims, image_start);
+
+		// if rescaling at the end, assume the input has also been rescaled
+		if (scale_im && scaling != 0.)
+			md_zsmul(DIMS, img_dims, image, image, 1. /  scaling);
 	}
 
 


### PR DESCRIPTION
`join`: Added to join the option to load files numbered sequentially:
```bash
bart join -p 0 256 slice_%03d full_data # join slice_000 through slice_255 along readout
```

`pics`: Added option to input scale factor (e.g. `-w 33`) and option to input a recon as a warm start (e.g. `-W image_start`)